### PR TITLE
install-app: Create /etc/linaro

### DIFF
--- a/roles/install-app/tasks/main.yml
+++ b/roles/install-app/tasks/main.yml
@@ -40,6 +40,16 @@
     - install
     - app
 
+- name: Create /etc/linaro/
+  file: path=/etc/linaro/
+        state=directory
+        owner=root
+        group={{ app_user }}
+        mode=0750
+  tags:
+    - install
+    - app
+
 - name: Copy app settings file
   template: src=flask_settings
             dest=/etc/linaro/kernelci-frontend.cfg


### PR DESCRIPTION
When running the playbook on a clean install, I get the following error:
TASK [install-app : Copy app settings file]
fatal: [kernelci-frontend]: FAILED! => {"changed": true, "failed": true, "msg": "Destination directory /etc/linaro does not exist"}

The install-app role need to create /etc/linaro before placing files inside