### PR TITLE
Update redis-server Ubuntu ppa repository

### DIFF
--- a/roles/install-deps/tasks/main.yml
+++ b/roles/install-deps/tasks/main.yml
@@ -32,7 +32,7 @@
     - install
 
 - name: Add redis PPA (Ubuntu)
-  apt_repository: repo='ppa:rwky/redis'
+  apt_repository: repo='ppa:chris-lea/redis-server'
                   update_cache=yes
   when: ansible_lsb.id == "Ubuntu"
   tags:


### PR DESCRIPTION
Update redis-server Ubuntu ppa repository,
previous one is error 404 now

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>