### PR TITLE
Prefer ansible_distribution over ansible_lsb.id

### DIFF
--- a/roles/configure-nginx/tasks/main.yml
+++ b/roles/configure-nginx/tasks/main.yml
@@ -32,14 +32,14 @@
 # we better run the node.js command locally and upload the file.
 - name: Copy static assests (for staging)
   command: rsync -a -u {{ install_base }}/{{ hostname }}/app/dashboard/static/ {{ web_root }}/{{ hostname }}/static
-  when: ansible_lsb.id == "Ubuntu"
+  when: ansible_distribution == "Ubuntu"
   tags:
     - web-server
     - app
 
 - name: Build static assets
   command: nodejs {{ install_base }}/{{ hostname }}/app/dashboard/static/js/lib/r.js -o {{ install_base }}/{{ hostname }}/app/dashboard/static/js/build.js
-  when: ansible_lsb.id == "Debian"
+  when: ansible_distribution == "Debian"
   tags:
     - web-server
     - app
@@ -50,14 +50,14 @@
         recurse=yes
         owner={{ app_user }}
         group={{ app_user }}
-  when: ansible_lsb.id == "Debian"
+  when: ansible_distribution == "Debian"
   tags:
     - web-server
     - app
 
 - name: Copy static assets
   command: rsync -a -u /tmp/assets-build/ {{ web_root }}/{{ hostname }}/static
-  when: ansible_lsb.id == "Debian"
+  when: ansible_distribution == "Debian"
   tags:
     - web-server
     - app

--- a/roles/install-deps/tasks/main.yml
+++ b/roles/install-deps/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Add nginx stable PPA repository
   apt_repository: repo='ppa:nginx/stable'
-  when: ansible_lsb.id == "Ubuntu"
+  when: ansible_distribution == "Ubuntu"
 
 - name: Install nginx
   apt:  pkg={{ item }}
@@ -34,7 +34,7 @@
 - name: Add redis PPA (Ubuntu)
   apt_repository: repo='ppa:chris-lea/redis-server'
                   update_cache=yes
-  when: ansible_lsb.id == "Ubuntu"
+  when: ansible_distribution == "Ubuntu"
   tags:
     - install
     - redis


### PR DESCRIPTION
ansible_lsb.id works only if OS support LSB (and have the correspoding
package).
It does not work on CentOS out of the box and it could be the same on
other OS.
Since ansible_distribution is always availlable, its better to use it.