### PR TITLE
Change the DATE_RANGE setting in flask_settings

### DIFF
--- a/roles/install-app/templates/flask_settings
+++ b/roles/install-app/templates/flask_settings
@@ -9,7 +9,7 @@ SECRET_KEY = '{{ secret_key }}'
 # Add the trailing slash!
 FILE_SERVER_URL = '{{ file_server }}'
 GOOGLE_ANALYTICS_ID = '{{ google_analytics }}'
-DATE_RANGE = 14
+DATE_RANGE = 5
 INFO_EMAIL = '{{ info_email }}'
 
 CACHE_TYPE = 'redis'


### PR DESCRIPTION
Due to issues with slowdown in the frontend when browsing a very large amount of results, only request 5 days worth of results instead of 14.