### PR TITLE
Replace /etc/linaro with /etc/kernelci

### DIFF
--- a/roles/install-app/tasks/main.yml
+++ b/roles/install-app/tasks/main.yml
@@ -40,8 +40,8 @@
     - install
     - app
 
-- name: Create /etc/linaro/
-  file: path=/etc/linaro/
+- name: Create /etc/kernelci/
+  file: path=/etc/kernelci/
         state=directory
         owner=root
         group=root
@@ -52,7 +52,7 @@
 
 - name: Copy app settings file
   template: src=flask_settings
-            dest=/etc/linaro/kernelci-frontend.cfg
+            dest=/etc/kernelci/kernelci-frontend.cfg
             owner=root
             group=root
             mode=0644


### PR DESCRIPTION
To match the change in kernelci-frontend, use /etc/kernelci to hold
the config files rather than /etc/linaro.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>