### PR TITLE
Update kernelci-frontend default branch name

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -4,7 +4,7 @@ hostname: kernelci-frontend
 web_user: www-data
 app_user: www-data
 web_root: /usr/share/nginx/html
-git_head: master
+git_head: main
 role: production
 uwsgi_port: 5000
 uwsgi_threads: 10


### PR DESCRIPTION
The default branch name in kernelci-frontend repo has been updated to
main on
 https://github.com/kernelci/kernelci-frontend/branches

Update the default branch name in ansible playbook to match the changes.

Signed-off-by: Andrew Lee <andrew.lee@collabora.co.uk>