### PR TITLE
Rename kernelci.org to linux.kernelci.org

### DIFF
--- a/host_vars/kernelci.org
+++ b/host_vars/kernelci.org
@@ -1,4 +1,0 @@
-hostname: kernelci.org
-role: production
-uwsgi_processes: 12
-certname: www.kernelci.org

--- a/host_vars/linux.kernelci.org
+++ b/host_vars/linux.kernelci.org
@@ -1,0 +1,4 @@
+hostname: linux.kernelci.org
+role: production
+uwsgi_processes: 12
+certname: kernelci.org

--- a/hosts
+++ b/hosts
@@ -5,7 +5,7 @@ kernelci-frontend
 staging.kernelci.org
 
 [prod]
-kernelci.org
+linux.kernelci.org
 
 [all:children]
 prod


### PR DESCRIPTION
Rename the kernelci.org host to linux.kernelci.org as the new static
website is now hosted on kernelci.org.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>