### PR TITLE
Fixes for ansible 2.9.x and Debian Buster

### DIFF
--- a/roles/common/files/sysctl.conf
+++ b/roles/common/files/sysctl.conf
@@ -33,7 +33,7 @@ net.core.optmem_max = 65535
 net.ipv4.tcp_max_tw_buckets = 1440000
 
 # Reuse TIME_WAIT connection if possible.
-net.ipv4.tcp_tw_recycle = 0
+#net.ipv4.tcp_tw_recycle = 0
 net.ipv4.tcp_tw_reuse = 1
 
 # Limit number of orphans, each orphan can eat up to 16M (max wmem)

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,8 +1,8 @@
 ---
+- include: sysctl.yml
 - include: apache.yml
 - include: nginx.yml
 - include: uwsgi.yml
-- include: sysctl.yml
 
 - name: reload-systemd
   command: /bin/systemctl daemon-reload

--- a/roles/common/tasks/sysctl.yml
+++ b/roles/common/tasks/sysctl.yml
@@ -9,3 +9,6 @@
     - reload-sysctl
   tags:
     - sysctl
+
+- name: Load new sysctl values
+  command: /sbin/sysctl -p

--- a/roles/configure-nginx/tasks/main.yml
+++ b/roles/configure-nginx/tasks/main.yml
@@ -258,12 +258,13 @@
       - https
       - web-server
 
-- name: Enable uwsgi systemd service
-  command:  /bin/systemctl enable uwsgi.service
-            creates=/etc/systemd/system/multi-user.target.wants/uwsgi.service
-  when: ansible_distribution == "Debian" or ansible_distribution == "CentOS"
-  notify:
-    - reload-systemd
-  tags:
-    - init
-    - systemd
+- name: Enable uwsgi service
+  ansible.builtin.systemd:
+    name: uwsgi
+    enabled: yes
+    masked: no
+
+- name: First start of uwsgi service
+  ansible.builtin.systemd:
+    name: uwsgi
+    state: restarted

--- a/roles/install-deps/tasks/main.yml
+++ b/roles/install-deps/tasks/main.yml
@@ -26,7 +26,7 @@
     - install
 
 - name: Centos 7.3 nodejs Hack (bug 1481008 / 1481470)
-  when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7" and ansible_distribution_version | search("7.3")
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7" and ansible_distribution_version is search("7.3")
   yum: name=https://kojipkgs.fedoraproject.org/packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
   tags:
     - install


### PR DESCRIPTION
Hi!
I would like to help the project, but i came across the fact that it looks like this recipe is a little outdated for modern versions of software.

This small patch fixes several problems:

- tcp_tw_recycle option removed from modern kernels, ansible was failing with error

`fatal: [kernelcifrontend]: FAILED! => {"changed": true, "cmd": ["sysctl", "-p"], "delta": "0:00:00.007153", "end": "2021-11-03 07:06:31.637304", "msg": "non-zero return code", "rc": 255, "start": "2021-11-03 07:06:31.630151", "stderr": "sysctl: cannot stat /proc/sys/net/ipv4/tcp_tw_recycle: No such file or directory", "stderr_lines": ["sysctl: cannot stat /proc/sys/net/ipv4/tcp_tw_recycle: No such file or directory"], `

- sysctl value net.core.somaxconn need to be updated before running uwsgi, otherwise uwsgi fail to start with error:
Wed Nov  3 06:13:38 2021 - Listen queue size is greater than the system max net.core.somaxconn (128).
And ansible error:
fatal: [kernelcifrontend]: FAILED! => {"changed": false, "msg": "Unable to reload service uwsgi: Job for uwsgi.service failed.\nSee \"systemctl status uwsgi.service\" and \"journalctl -xe\" for details.\n"}

- We cannot rely on ansible handler to run sysctl update, because handlers run after particular play completed, so i apply sysctl update directly after updating file.

- uwsgi need to be properly started first time, not reloaded, it seems creating some directories such way. If it is reloaded without "preparatory" start, it will fail.

-  ansible syntax changed a bit, after ansible 2.5 jinja test syntax considered deprecated and it is removed in ansible 2.9
https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters

Error was: `TASK [install-deps : Centos 7.3 nodejs Hack (bug 1481008 / 1481470)] ***********
fatal: [kernelcifrontend]: FAILED! => {"msg": "The conditional check 'ansible_distribution == \"CentOS\" and ansible_distribution_major_version == \"7\" and ansible_distribution_version | search(\"7.3\")' failed. The error was: template error while templating string: no filter named 'search'. String: {% if ansible_distribution == \"CentOS\" and ansible_distribution_major_version == \"7\" and ansible_distribution_version | search(\"7.3\") %} True {% else %} False {% endif %}\n\nThe error appears to be in '/root/KERNELCI/INSTALL/kernelci-frontend-config/roles/install-deps/tasks/main.yml': line 28, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Centos 7.3 nodejs Hack (bug 1481008 / 1481470)\n  ^ here\n"}
`