### PR TITLE
install-app/tasks/main.yml: Fix permissions before git update

### DIFF
--- a/roles/install-app/tasks/main.yml
+++ b/roles/install-app/tasks/main.yml
@@ -1,4 +1,28 @@
 ---
+- name: Retrieve current userid
+  command: id -u
+  register: userid
+  tags:
+    - install
+    - app
+
+- name: Retrieve current groupid
+  command: id -g
+  register: groupid
+  tags:
+    - install
+    - app
+
+- name: Chown to current user to make git happy (CVE-2022-24765)
+  file: path={{ install_base }}/{{ hostname }}
+        state=directory
+        recurse=yes
+        owner={{ userid.stdout }}
+        group={{ groupid.stdout }}
+  tags:
+    - install
+    - app
+
 - name: Checkout kernel-ci-frontend code
   git:  repo=https://github.com/kernelci/kernelci-frontend.git
         dest={{ install_base }}/{{ hostname }}


### PR DESCRIPTION
git 1:2.20.1-2+deb10u5 is a security update for CVE-2022-24765 which prevents git from executing when the workspace .git directory is owned by another user than the invoking user.
We are changing ownership for www-data later, so we need temporary set ownership to current user during git operations.