### PR TITLE
Create virtualenv with python2.7

### DIFF
--- a/roles/install-app/tasks/main.yml
+++ b/roles/install-app/tasks/main.yml
@@ -47,6 +47,7 @@
 - name: Install pip requirements
   pip:  requirements={{ install_base }}/{{ hostname }}/requirements.txt
         virtualenv={{ install_base }}/.venv/{{ hostname }}
+        virtualenv_python=python2.7
         extra_args="--upgrade"
   notify:
     - reload-uwsgi


### PR DESCRIPTION
Define Python interpreter used to create a virtualenv for kernelci-frontend to make sure python 2.7 is used.